### PR TITLE
AST printer quick fix

### DIFF
--- a/src/AstPrinter.java
+++ b/src/AstPrinter.java
@@ -30,6 +30,10 @@ public class AstPrinter implements Expr.Visitor<String> {
 
 	@Override
 	public String visit(Expr.Literal expr) {
+		if (expr.getValue() == null) {
+			return "nil";
+		}
+
 		return expr
 			.getValue()
 			.toString();


### PR DESCRIPTION
Handle seeing null literal

```
Expr nil = new Expr.Literal(null);
```

This will then check if the Literal value is null and then print `nil` instead of `null`